### PR TITLE
Add support for using several message-digest algorithms

### DIFF
--- a/zookeeper-it/src/main/java/org/apache/zookeeper/test/system/InstanceManager.java
+++ b/zookeeper-it/src/main/java/org/apache/zookeeper/test/system/InstanceManager.java
@@ -21,6 +21,7 @@ package org.apache.zookeeper.test.system;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.HashMap;
+import java.util.Set;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
@@ -190,7 +191,22 @@ public class InstanceManager implements AsyncCallback.ChildrenCallback, Watcher 
                 }
             }
         }
-        for(Entry<String, HashSet<Assigned>> e: assignments.entrySet()) {
+
+        Set<Entry<String, HashSet<Assigned>>> ics = new HashSet<>();
+        for (Entry<String, HashSet<Assigned>> e: assignments.entrySet()) {
+            if (name.startsWith("client") && e.getKey().startsWith("cic-")) {
+                ics.add(e);
+            } else if (name.startsWith("server") && e.getKey().startsWith("sic-")) {
+                ics.add(e);
+            }
+        }
+
+        // default case
+        if (ics.size() == 0) {
+            ics = assignments.entrySet();
+        }
+
+        for(Entry<String, HashSet<Assigned>> e: ics) {
             int w = 0;
             for(Assigned a: e.getValue()) {
                 w += a.weight;

--- a/zookeeper-server/src/main/java/org/apache/zookeeper/server/DigestCalculator.java
+++ b/zookeeper-server/src/main/java/org/apache/zookeeper/server/DigestCalculator.java
@@ -140,6 +140,8 @@ public class DigestCalculator {
         return DIGEST_VERSION;
     }
 
+
+    // todo: move to separate files
     interface Fingerprint {
 
         long get(byte[] data);
@@ -151,7 +153,6 @@ public class DigestCalculator {
 
         MdFingerprint() {
             try {
-                System.out.println("****** Creating Message Digest ******");
                 md = MessageDigest.getInstance(ZooKeeperServer.getDigestAlgo());
             } catch (NoSuchAlgorithmException notExpected) {
                 throw new IllegalStateException("Unsupported message digest algorithm");

--- a/zookeeper-server/src/main/java/org/apache/zookeeper/server/DigestCalculator.java
+++ b/zookeeper-server/src/main/java/org/apache/zookeeper/server/DigestCalculator.java
@@ -37,6 +37,9 @@ public class DigestCalculator {
     private Fingerprint fp;
 
     public DigestCalculator() {
+        if (!ZooKeeperServer.isDigestEnabled()) {
+            return;
+        }
         if ("CRC-32".equals(ZooKeeperServer.getDigestAlgo())) {
             fp = new CrcFingerprint();
         } else {

--- a/zookeeper-server/src/main/java/org/apache/zookeeper/server/ZooKeeperServer.java
+++ b/zookeeper-server/src/main/java/org/apache/zookeeper/server/ZooKeeperServer.java
@@ -111,8 +111,10 @@ public class ZooKeeperServer implements SessionExpirer, ServerStats.Provider {
     public static final String SASL_AUTH_SCHEME = "sasl";
 
     public static final String ZOOKEEPER_DIGEST_ENABLED = "zookeeper.digest.enabled";
+    public static final String ZOOKEEPER_PREDICTIVE_DIGEST = "zookeeper.predictive.digest";
     public static final String ZOOKEEPER_DIGEST_ALGORITHM = "zookeeper.digest.algorithm";
     private static boolean digestEnabled;
+    private static boolean predictiveDigest;
     private static String digestAlgo;
 
     // Add a enable/disable option for now, we should remove this one when
@@ -144,6 +146,8 @@ public class ZooKeeperServer implements SessionExpirer, ServerStats.Provider {
                 throw new IllegalArgumentException("Unknown hash function: " + digestAlgo);
             }
             LOG.info("{} = {}", ZOOKEEPER_DIGEST_ALGORITHM, digestAlgo);
+            predictiveDigest = Boolean.parseBoolean(System.getProperty(ZOOKEEPER_PREDICTIVE_DIGEST, "true"));
+            LOG.info("{} = {}", ZOOKEEPER_PREDICTIVE_DIGEST, predictiveDigest);
         }
 
         closeSessionTxnEnabled = Boolean.parseBoolean(
@@ -1967,6 +1971,10 @@ public class ZooKeeperServer implements SessionExpirer, ServerStats.Provider {
 
     public static String getDigestAlgo() {
         return digestAlgo;
+    }
+
+    public static boolean isPrecalculateDigest() {
+        return predictiveDigest;
     }
 
     /**


### PR DESCRIPTION
With this patch we can use algorithms such as MD5, SHA-256, and SHA-512 to compute digest in AdHASH.
